### PR TITLE
return a single node when applicable

### DIFF
--- a/packages/react/src/format.ts
+++ b/packages/react/src/format.ts
@@ -87,7 +87,7 @@ function formatElements(
     if (after) tree.push(after)
   }
 
-  return tree
+  return tree.length === 1 ? tree[0] : tree;
 }
 
 /*


### PR DESCRIPTION
# Description


Fixes an issue where `<Trans>` didn't work as expected when using `asChild`, which is most commonly used with [Radix](https://www.radix-ui.com/primitives) (and [shadcn/ui](https://ui.shadcn.com/), which is based on it).

Fixes https://github.com/lingui/js-lingui/issues/2015

## Types of changes

[//]: # (What types of changes does your code introduce to Lingui?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Examples update

Fixes #2015

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/lingui/js-lingui/blob/main/CONTRIBUTING.md) and [CODE_OF_CONDUCT](https://github.com/lingui/js-lingui/blob/main/CODE_OF_CONDUCT.md) docs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
